### PR TITLE
Remove use-package require-statement

### DIFF
--- a/emacs/.emacs.d/init.el
+++ b/emacs/.emacs.d/init.el
@@ -50,12 +50,6 @@
 ;; quick start cache.
 (package-activate-all)
 
-;; Load `use-package`.
-(unless (package-installed-p 'use-package)
-  (package-refresh-contents)
-  (package-install 'use-package))
-(require 'use-package)
-
 ;; My favorite theme.
 ;; Don't defer this, I need it all time.
 (use-package atom-one-dark-theme


### PR DESCRIPTION
Arch Linux 用户想必会用上最新的 Emacs 吧, v29 已经内置了 `use-package`.